### PR TITLE
fix(plugins/gemini): allow empty prompt when replying to an image

### DIFF
--- a/plugins/gemini.js
+++ b/plugins/gemini.js
@@ -11,7 +11,7 @@ bot(
       return await message.send(lang.plugins.gemini.Key)
     }
 
-    if (!match) {
+    if (!match && !(message.reply_message && message.reply_message.image)) {
       return await message.send(lang.plugins.gemini.example)
     }
 


### PR DESCRIPTION
Allows the gemini command to proceed without requiring a match prompt if the user is replying to an image, utilizing the fallback default prompt 'Describe this image.'